### PR TITLE
Explore zsh history for path executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ cd taipo
 ## 💻 Usage 
 **taipo** will automatically be invoked any time your shell doesn't recognize a command ✨ no command line muscle memory changes needed!
 
+### Smarter suggestions
+
+To improve ergonomics, taipo now considers:
+
+- Commands discoverable on your `PATH` (via zsh `$commands`)
+- Recent entries from your `~/.zsh_history` to surface locally-invoked scripts or tools (including `./scripts/foo` becoming `foo`)
+
+This helps corrections prefer things you actually use, even if they are project scripts or binaries not globally installed.
+
 ## 💡 Modes
 
 - 🟢 **manual**: You'll be prompted before any suggested command is run.

--- a/taipo.py
+++ b/taipo.py
@@ -8,6 +8,7 @@ import subprocess
 import re
 from yaspin import yaspin
 import difflib
+from typing import List, Tuple
 
 DEBUG_MODE = os.getenv("TAIPO_DEBUG") == "1"
 
@@ -24,16 +25,108 @@ def load_config():
     except (FileNotFoundError, json.JSONDecodeError, KeyError):
         return "manual"  # Default to manual mode
 
-def get_suggested_command(command: str, available_commands: str, smart_mode: bool = False) -> tuple[str, float]:
+def _get_path_commands() -> List[str]:
+    """Return a list of executable basenames discoverable via zsh $commands."""
+    try:
+        # Use zsh to reliably enumerate commands found on PATH
+        output = subprocess.getoutput("zsh -c 'print -rlo -- $commands:t'")
+        return [line.strip() for line in output.splitlines() if line.strip()]
+    except Exception:
+        return []
+
+
+def _parse_zsh_history_commands(max_lines: int = 5000) -> List[str]:
+    """Parse ~/.zsh_history for first tokens of recent commands.
+
+    - Extracts the base command token (and, if prefixed by sudo, also the next token)
+    - Includes both raw token and basename for path-like tokens (e.g., ./scripts/deploy -> deploy)
+    - Deduplicates while preserving insertion order approximately by processing from the end
+    """
+    history_path = os.path.expanduser("~/.zsh_history")
+    if not os.path.exists(history_path):
+        return []
+
+    try:
+        with open(history_path, "r", encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+    except Exception:
+        return []
+
+    tokens_seen = set()
+    ordered_tokens: List[str] = []
+
+    # Work backwards to favor most recent usage
+    for line in reversed(lines[-max_lines:]):
+        # zsh history lines commonly look like: ": 1700000000:0;git status"
+        # We want the portion after the last ';' if present
+        try:
+            command_text = line.split(";", 1)[1].strip()
+        except IndexError:
+            command_text = line.strip()
+        if not command_text:
+            continue
+
+        parts = command_text.split()
+        if not parts:
+            continue
+
+        first = parts[0]
+
+        # Also capture the command after sudo as a strong signal
+        if first == "sudo" and len(parts) > 1:
+            candidate_after_sudo = parts[1]
+            for cand in (first, candidate_after_sudo):
+                # Add raw token
+                if cand not in tokens_seen:
+                    tokens_seen.add(cand)
+                    ordered_tokens.append(cand)
+                # If path-like, also add basename
+                base = os.path.basename(cand)
+                if base and base != cand and base not in tokens_seen:
+                    tokens_seen.add(base)
+                    ordered_tokens.append(base)
+            continue
+
+        # Regular first token
+        cand = first
+        if cand not in tokens_seen:
+            tokens_seen.add(cand)
+            ordered_tokens.append(cand)
+        base = os.path.basename(cand)
+        if base and base != cand and base not in tokens_seen:
+            tokens_seen.add(base)
+            ordered_tokens.append(base)
+
+    return ordered_tokens
+
+
+def _aggregate_candidate_commands() -> List[str]:
+    """Combine PATH-discoverable commands with commands gleaned from zsh history."""
+    path_cmds = _get_path_commands()
+    hist_cmds = _parse_zsh_history_commands()
+
+    combined = []
+    seen = set()
+    for source_list in (path_cmds, hist_cmds):
+        for cmd in source_list:
+            if not cmd:
+                continue
+            if cmd in seen:
+                continue
+            seen.add(cmd)
+            combined.append(cmd)
+    return combined
+
+
+def get_suggested_command(command: str, candidate_commands: List[str], smart_mode: bool = False) -> Tuple[str, float]:
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         print("❌ Please set your OPENAI_API_KEY in your environment.")
         sys.exit(1)
 
-    available_commands = subprocess.getoutput("zsh -c 'print -rlo -- $commands:t'")
-    command_list = available_commands.splitlines()
-    base_command = command.split()[0]
-    close_matches = difflib.get_close_matches(base_command, command_list, n=5, cutoff=0.75)
+    # Build close matches from provided candidate commands (PATH + history)
+    base_command = command.split()[0] if command.strip() else ""
+    close_matches = difflib.get_close_matches(base_command, candidate_commands, n=8, cutoff=0.7)
 
     if smart_mode:
         prompt = (
@@ -43,7 +136,7 @@ def get_suggested_command(command: str, available_commands: str, smart_mode: boo
             "2. 'confidence': a number between 0.0 and 1.0 indicating your confidence in this correction\n"
             "Example: {\"command\": \"git status\", \"confidence\": 0.95}\n"
             "If you cannot confidently fix it, use a low confidence score (0.0-0.3).\n"
-            f"The most similar known commands to '{command}' are: {close_matches}"
+            f"Consider these similar commands (from PATH and recent history): {close_matches}"
         )
     else:
         prompt = (
@@ -51,7 +144,7 @@ def get_suggested_command(command: str, available_commands: str, smart_mode: boo
             "If it's a typo, respond only with the corrected command. "
             "If it cannot be confidently fixed, respond with a general suggestion. "
             "No explanations or extra text—just a corrected command.\n"
-            f"The most similar known commands to '{command}' are: {close_matches}"
+            f"Consider these similar commands (from PATH and recent history): {close_matches}"
         )
     if DEBUG_MODE:
         print("\033[94m🐛 [TAIPO_DEBUG] OpenAI prompt:\n" + prompt + "\033[0m")
@@ -135,11 +228,16 @@ def main():
 
         failed_command = args.split()[0]
 
-        available_commands_string = subprocess.getoutput("print -- $commands:t")
+        # Aggregate candidate commands once to guide the suggestion
+        candidate_commands = _aggregate_candidate_commands()
 
         with yaspin(text=f"[taipo] Trying to make sense of: '{args}'...", color="cyan", side="right") as spinner:
             mode = load_config()
-            suggestion, confidence = get_suggested_command(args, available_commands=available_commands_string, smart_mode=(mode == "smart"))
+            suggestion, confidence = get_suggested_command(
+                args,
+                candidate_commands=candidate_commands,
+                smart_mode=(mode == "smart"),
+            )
             spinner.ok("✔")
 
         if DEBUG_MODE:


### PR DESCRIPTION
Enhance command suggestions by incorporating zsh history, improving ergonomics by including frequently used local scripts.

Previously, `taipo` only considered commands found directly on the system's PATH. This PR extends the candidate pool for `difflib.get_close_matches` by parsing `~/.zsh_history`, allowing `taipo` to suggest locally-invoked scripts or project-specific binaries (e.g., `./scripts/foo` becoming `foo`) that are not globally installed, making suggestions more relevant to the user's actual usage patterns.

---
<a href="https://cursor.com/background-agent?bcId=bc-48a0e72f-82af-44c5-9727-b219617f4364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48a0e72f-82af-44c5-9727-b219617f4364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

